### PR TITLE
replace process.nextTick with setImmediate to fix 'RangeError: Maximum call stack size exceeded'

### DIFF
--- a/pullstream.js
+++ b/pullstream.js
@@ -45,7 +45,7 @@ PullStream.prototype.pull = over([
 
       var data = self.read(len || undefined);
       if (data) {
-        process.nextTick(callback.bind(null, null, data));
+        setImmediate(callback.bind(null, null, data));
       } else {
         self._serviceRequests = pullServiceRequest;
       }
@@ -109,7 +109,7 @@ PullStream.prototype.drain = function (len, callback) {
   var data = this.pullUpTo(len);
   var bytesDrained = data && data.length || 0;
   if (bytesDrained === len) {
-     process.nextTick(callback);
+     setImmediate(callback);
   } else if (bytesDrained > 0) {
     this.drain(len - bytesDrained, callback);
   } else {
@@ -137,5 +137,5 @@ PullStream.prototype._finish = function (callback) {
   if (this._serviceRequests) {
     this._serviceRequests();
   }
-  process.nextTick(callback);
+  setImmediate(callback);
 };


### PR DESCRIPTION
[node-unzip](https://github.com/nearinfinity/node-unzip) depends on node-pullstream, but unzipping certain archives generates a bunch of:

> (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.

Followed by:

> RangeError: Maximum call stack size exceeded

node-unzip had a similar problem in its own code and fixed it by replacing _process.nextTick_ calls with _setImmediate_ (nearinfinity/node-unzip#28). This PR does the same for node-pullstream and fixes the problem unzipping files in my testing.
